### PR TITLE
removing `remultOrDP` as first param

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ import { api } from "~/api"
 import { User, Account, Session, Verification } from "./src/auth-schema" // generated via the cli
 
 return betterAuth({
-	database: remultAdapter(api.getRemult(), {
+	database: remultAdapter({
 		authEntities: {User, Account, Session, Verification},
 	}),
 	...anyOtherBetterAuthOptions

--- a/examples/auth.ts
+++ b/examples/auth.ts
@@ -9,7 +9,7 @@ export const auth = betterAuth({
 			email: "email_address",
 		},
 	},
-	database: remultAdapter(new InMemoryDataProvider(), {
+	database: remultAdapter({
 		// no need to declare entities when we're generating them
 		authEntities: {},
 		usePlural: true

--- a/src/dev-generate-schema.ts
+++ b/src/dev-generate-schema.ts
@@ -1,6 +1,5 @@
 import { writeFile } from "node:fs/promises"
 import { type BetterAuthOptions, logger } from "better-auth"
-import { Remult } from "remult"
 import { type RemultAdapterOptions, remultAdapter } from "./remult-ba"
 
 export async function generateRemultSchema({
@@ -12,10 +11,10 @@ export async function generateRemultSchema({
 	file: string
 	adapterOptions?: Omit<RemultAdapterOptions, "authEntities">
 }) {
-	const adapter = remultAdapter(new Remult(), {
+	const adapter = remultAdapter({
+		...adapterOptions,
 		// for schema generation, we don't need to declare entities.
 		authEntities: {},
-		...adapterOptions
 	})(options)
 
 	if (!adapter.createSchema) {

--- a/src/remult-ba.test.ts
+++ b/src/remult-ba.test.ts
@@ -61,13 +61,14 @@ async function testSuite(
 ) {
 	const remult = new Remult(dbProvider)
 
-	const adapterFn = remultAdapter(remult.dataProvider, {
+	const adapterFn = remultAdapter( {
 		authEntities,
 		debugLogs: {
 			// If your adapter config allows passing in debug logs, then pass this here.
 			isRunningAdapterTests: true, // This is our super secret flag to let us know to only log debug logs if a test fails.
 		},
 		usePlural,
+		remult,
 	})
 
 	beforeAll(async () => {

--- a/src/remult-ba.test.ts
+++ b/src/remult-ba.test.ts
@@ -56,10 +56,10 @@ describe("remult-better-auth", async () => {
 
 async function testSuite(
 	authEntities: Record<string, ClassType<unknown>>,
-	dbProvider: DataProvider,
+	dataProvider: DataProvider,
 	usePlural = false
 ) {
-	const remult = new Remult(dbProvider)
+	const remult = new Remult(dataProvider)
 
 	const adapterFn = remultAdapter( {
 		authEntities,
@@ -68,7 +68,7 @@ async function testSuite(
 			isRunningAdapterTests: true, // This is our super secret flag to let us know to only log debug logs if a test fails.
 		},
 		usePlural,
-		remult,
+		dataProvider,
 	})
 
 	beforeAll(async () => {

--- a/src/remult-ba.ts
+++ b/src/remult-ba.ts
@@ -1,6 +1,6 @@
 import { capitalizeFirstLetter } from "better-auth"
 import { type AdapterDebugLogs, type CleanedWhere, type CustomAdapter, createAdapter } from "better-auth/adapters"
-import { type ClassType, type ErrorInfo, Remult, type Repository, SqlDatabase, withRemult } from "remult"
+import { type ClassType, DataProvider, type ErrorInfo, Remult, type Repository, SqlDatabase, withRemult } from "remult"
 import { transformSchema } from "./transform-model"
 import { transformWhereClause } from "./transform-where"
 import { RemultBetterAuthError } from "./utils"
@@ -20,7 +20,11 @@ export interface RemultAdapterOptions {
 	 */
 	usePlural?: boolean
 
-	remult?: Remult
+	/**
+	 * If you want to use a different data provider
+	 * You can give it explicitly here. Could be useful for testing.
+	 */
+	dataProvider?: DataProvider
 }
 
 /**
@@ -36,7 +40,7 @@ export function remultAdapter(adapterCfg: RemultAdapterOptions) {
 
 	async function getRepo(modelName: string) {
 		return await withRemult(async (localRemult) => {
-			const remult = adapterCfg.remult ?? localRemult
+			const remult = adapterCfg.dataProvider ? new Remult(adapterCfg.dataProvider) : localRemult
 			if (!authRepos) {
 				authRepos = Object.fromEntries(
 					Object.values(adapterCfg.authEntities)

--- a/src/remult-ba.ts
+++ b/src/remult-ba.ts
@@ -1,6 +1,6 @@
 import { capitalizeFirstLetter } from "better-auth"
 import { type AdapterDebugLogs, type CleanedWhere, type CustomAdapter, createAdapter } from "better-auth/adapters"
-import { type ClassType, DataProvider, type ErrorInfo, Remult, type Repository, SqlDatabase, withRemult } from "remult"
+import { type ClassType, type DataProvider, type ErrorInfo, Remult, type Repository, SqlDatabase, withRemult } from "remult"
 import { transformSchema } from "./transform-model"
 import { transformWhereClause } from "./transform-where"
 import { RemultBetterAuthError } from "./utils"


### PR DESCRIPTION
Actually `remultOrDP` is completely optional in most scenario & simplifies a lot the `UserLand` setup.

I added `dataProvider` in the options